### PR TITLE
Switch to jupyter_client from IPython.kernel

### DIFF
--- a/jupyter_console/interactiveshell.py
+++ b/jupyter_console/interactiveshell.py
@@ -109,8 +109,8 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
         """
     )
 
-    manager = Instance('IPython.kernel.KernelManager', allow_none=True)
-    client = Instance('IPython.kernel.KernelClient', allow_none=True)
+    manager = Instance('jupyter_client.KernelManager', allow_none=True)
+    client = Instance('jupyter_client.KernelClient', allow_none=True)
     def _client_changed(self, name, old, new):
         self.session_id = new.session.session
     session_id = Unicode()

--- a/jupyter_console/interactiveshell.py
+++ b/jupyter_console/interactiveshell.py
@@ -433,7 +433,7 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
             self.client.shutdown()
 
     def _banner1_default(self):
-        return "IPython Console {version}\n".format(version=release.version)
+        return "Jupyter Console {version}\n".format(version=release.version)
     
     def compute_banner(self):
         super(ZMQTerminalInteractiveShell, self).compute_banner()


### PR DESCRIPTION
This was displaying a warning when running `jupyter console`.

```
UserWarning: The `IPython.kernel` package has been deprecated. You should import from ipykernel or jupyter_client instead.
```

Now it's using jupyter_client's kernel manager and kernel client.