### PR TITLE
Fill readline history in interact()

### DIFF
--- a/jupyter_console/interactiveshell.py
+++ b/jupyter_console/interactiveshell.py
@@ -503,6 +503,7 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
         if self.has_readline:
             self.readline_startup_hook(self.pre_readline)
             hlen_b4_cell = self.readline.get_current_history_length()
+            self.refill_readline_hist()
         else:
             hlen_b4_cell = 0
         # exit_now is set by a call to %Exit or %Quit, through the


### PR DESCRIPTION
History for readline is not filled when jupyter-console is run with `--matplotlib` or `--pylab`. This fixes that issue.

closes ipython/ipython#8899