### PR TITLE
Don't inherit from TerminalIPythonApp application class

### DIFF
--- a/jupyter_console/app.py
+++ b/jupyter_console/app.py
@@ -100,8 +100,6 @@ class ZMQTerminalIPythonApp(JupyterApp, JupyterConsoleApp):
         self.build_kernel_argv(self.extra_args)
 
     def init_shell(self):
-        if self._dispatching:
-            raise NoStart()
         JupyterConsoleApp.initialize(self)
         # relay sigint to kernel
         signal.signal(signal.SIGINT, self.handle_sigint)
@@ -137,6 +135,8 @@ class ZMQTerminalIPythonApp(JupyterApp, JupyterConsoleApp):
     def initialize(self, argv=None):
         """Do actions after construct, but before starting the app."""
         super(ZMQTerminalIPythonApp, self).initialize(argv)
+        if self._dispatching:
+            return
         # create the shell
         self.init_shell()
         # and draw the banner

--- a/jupyter_console/app.py
+++ b/jupyter_console/app.py
@@ -10,8 +10,6 @@ input, there is no real readline support, among other limitations.
 import logging
 import signal
 
-from IPython.terminal.ipapp import TerminalIPythonApp, frontend_flags as term_flags
-
 from traitlets import (
     Dict, Any
 )
@@ -43,10 +41,6 @@ jupyter console --existing # connect to an existing ipython session
 flags = dict(base_flags)
 # start with mixin frontend flags:
 frontend_flags = dict(app_flags)
-# add TerminalIPApp flags:
-frontend_flags.update(term_flags)
-# disable quick startup, as it won't propagate to the kernel anyway
-frontend_flags.pop('quick')
 # update full dict with frontend flags:
 flags.update(frontend_flags)
 


### PR DESCRIPTION
The main practical effect of this is that jupyter console will look for its config in standard jupyter locations, rather than in IPython locations. But it's also conceptually better to disentangle jupyter_console from IPython.

Closes gh-31