### PR TITLE
Don't try to detect virtualenv in the frontend

### DIFF
--- a/jupyter_console/interactiveshell.py
+++ b/jupyter_console/interactiveshell.py
@@ -687,3 +687,7 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
         else:
             more = (line != "")
             return more, ""
+
+    def init_virtualenv(self):
+        # No need to do this in the frontend, and the warning is confusing
+        pass


### PR DESCRIPTION
There's no point doing the virtualenv check in the frontend, and the extra warning message is confusing.

ipython/ipykernel#96 is for discussion, this one should just be a bugfix.