### PR TITLE
Use prompt_toolkit for jupyter_console

### DIFF
--- a/jupyter_console/_version.py
+++ b/jupyter_console/_version.py
@@ -1,2 +1,2 @@
-version_info = (4, 2, 0, 'dev')
+version_info = (5, 0, 0, 'dev')
 __version__ = '.'.join(map(str, version_info))

--- a/jupyter_console/app.py
+++ b/jupyter_console/app.py
@@ -21,7 +21,7 @@ from jupyter_client.consoleapp import (
         JupyterConsoleApp, app_aliases, app_flags,
     )
 
-from jupyter_console.interactiveshell import ZMQTerminalInteractiveShell
+from jupyter_console.ptshell import PTInteractiveShell as ZMQTerminalInteractiveShell
 from jupyter_console import __version__
 
 #-----------------------------------------------------------------------------

--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -67,6 +67,7 @@ class JupyterPTCompleter(Completer):
 
 class PTInteractiveShell(ZMQTerminalInteractiveShell):
     colors_force = True
+    readline_use = False
 
     pt_cli = None
 

--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -29,10 +29,11 @@ from prompt_toolkit.layout.lexers import PygmentsLexer
 from prompt_toolkit.styles import PygmentsStyle
 
 from pygments.styles import get_style_by_name
-from pygments.lexers import find_lexer_class
+from pygments.lexers import LEXERS, find_lexer_class
 from pygments.token import Token
 
 def get_pygments_lexer(name):
+    name = name.lower()
     if name == 'ipython2':
         from IPython.lib.lexers import IPythonLexer
         return IPythonLexer
@@ -40,12 +41,13 @@ def get_pygments_lexer(name):
         from IPython.lib.lexers import IPython3Lexer
         return IPython3Lexer
     else:
-        cls = find_lexer_class(name)
-        if cls is None:
-            warn("No lexer found for language %r. Treating as plain text." % name)
-            from pygments.lexers.special import TextLexer
-            return TextLexer
-        return cls
+        for module_name, cls_name, aliases, _, _ in LEXERS.values():
+            if name in aliases:
+                return find_lexer_class(cls_name)
+
+        warn("No lexer found for language %r. Treating as plain text." % name)
+        from pygments.lexers.special import TextLexer
+        return TextLexer
 
 
 class JupyterPTCompleter(Completer):

--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -191,7 +191,9 @@ class PTInteractiveShell(ZMQTerminalInteractiveShell):
         app = create_prompt_application(multiline=True,
                             lexer=PygmentsLexer(get_pygments_lexer(lexer)),
                             get_prompt_tokens=self.get_prompt_tokens,
-                            get_continuation_tokens=self.get_continuation_tokens,
+                            # Uncomment this when there's a new release of
+                            # prompt_toolkit (> 0.57)
+                            #get_continuation_tokens=self.get_continuation_tokens,
                             key_bindings_registry=kbmanager.registry,
                             history=history,
                             completer=JupyterPTCompleter(self.Completer),

--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -1,6 +1,7 @@
 """IPython terminal interface using prompt_toolkit in place of readline"""
 from __future__ import print_function
 
+import os
 import sys
 import time
 from warnings import warn
@@ -126,6 +127,14 @@ class PTInteractiveShell(ZMQTerminalInteractiveShell):
                     return
 
     def init_prompt_toolkit_cli(self):
+        if 'JUPYTER_CONSOLE_TEST' in os.environ:
+            # Simple restricted interface for tests so we can find prompts with
+            # pexpect. Multi-line input not supported.
+            def prompt():
+                return cast_unicode_py2(input('In [%d]: ' % self.execution_count))
+            self.prompt_for_code = prompt
+            return
+
         kbmanager = KeyBindingManager.for_prompt(enable_vi_mode=self.vi_mode)
         insert_mode = ViStateFilter(kbmanager.get_vi_state, InputMode.INSERT)
         # Ctrl+J == Enter, seemingly
@@ -203,6 +212,10 @@ class PTInteractiveShell(ZMQTerminalInteractiveShell):
 
         self.pt_cli = CommandLineInterface(app)
 
+    def prompt_for_code(self):
+        document = self.pt_cli.run(pre_run=self.pre_prompt)
+        return document.text
+
     def init_io(self):
         if sys.platform not in {'win32', 'cli'}:
             return
@@ -236,14 +249,14 @@ class PTInteractiveShell(ZMQTerminalInteractiveShell):
             print('\n', end='')
 
             try:
-                document = self.pt_cli.run(pre_run=self.pre_prompt)
+                code = self.prompt_for_code()
             except EOFError:
                 if self.ask_yes_no('Do you really want to exit ([y]/n)?','y','n'):
                     self.ask_exit()
 
             else:
-                if document:
-                    self.run_cell(document.text, store_history=True)
+                if code:
+                    self.run_cell(code, store_history=True)
 
     def mainloop(self):
         # An extra layer of protection in case someone mashing Ctrl-C breaks

--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -243,3 +243,12 @@ class PTInteractiveShell(ZMQTerminalInteractiveShell):
                 if document:
                     self.run_cell(document.text, store_history=True)
 
+    def mainloop(self):
+        # An extra layer of protection in case someone mashing Ctrl-C breaks
+        # out of our internal code.
+        while True:
+            try:
+                self.interact()
+                break
+            except KeyboardInterrupt:
+                print("\nKeyboardInterrupt escaped interact()\n")

--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -48,21 +48,21 @@ def get_pygments_lexer(name):
         return cls
 
 
-class IPythonPTCompleter(Completer):
-    """Adaptor to provide IPython completions to prompt_toolkit"""
-    def __init__(self, ipy_completer):
-        self.ipy_completer = ipy_completer
+class JupyterPTCompleter(Completer):
+    """Adaptor to provide kernel completions to prompt_toolkit"""
+    def __init__(self, jup_completer):
+        self.jup_completer = jup_completer
 
     def get_completions(self, document, complete_event):
         if not document.current_line.strip():
             return
 
-        used, matches = self.ipy_completer.complete(
-                            line_buffer=document.current_line,
-                            cursor_pos=document.cursor_position_col
+        content = self.jup_completer.complete_request(
+                            code=document.text,
+                            cursor_pos=document.cursor_position
         )
-        start_pos = -len(used)
-        for m in matches:
+        start_pos = content['cursor_start'] - document.cursor_position
+        for m in content['matches']:
             yield Completion(m, start_position=start_pos)
 
 class PTInteractiveShell(ZMQTerminalInteractiveShell):
@@ -191,7 +191,7 @@ class PTInteractiveShell(ZMQTerminalInteractiveShell):
                             get_continuation_tokens=self.get_continuation_tokens,
                             key_bindings_registry=kbmanager.registry,
                             history=history,
-                            completer=IPythonPTCompleter(self.Completer),
+                            completer=JupyterPTCompleter(self.Completer),
                             enable_history_search=True,
                             style=style,
         )

--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -1,0 +1,188 @@
+"""IPython terminal interface using prompt_toolkit in place of readline"""
+from __future__ import print_function
+
+import sys
+
+from IPython.utils.py3compat import PY3, cast_unicode_py2
+from traitlets import Bool, Integer, Unicode, Dict
+
+from .interactiveshell import ZMQTerminalInteractiveShell
+
+from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.enums import DEFAULT_BUFFER
+from prompt_toolkit.filters import HasFocus, HasSelection
+from prompt_toolkit.history import InMemoryHistory
+from prompt_toolkit.shortcuts import create_prompt_application
+from prompt_toolkit.interface import CommandLineInterface
+from prompt_toolkit.key_binding.manager import KeyBindingManager
+from prompt_toolkit.key_binding.vi_state import InputMode
+from prompt_toolkit.key_binding.bindings.vi import ViStateFilter
+from prompt_toolkit.keys import Keys
+from prompt_toolkit.layout.lexers import PygmentsLexer
+from prompt_toolkit.styles import PygmentsStyle
+
+from pygments.styles import get_style_by_name
+from pygments.lexers import Python3Lexer, PythonLexer
+from pygments.token import Token
+
+
+class IPythonPTCompleter(Completer):
+    """Adaptor to provide IPython completions to prompt_toolkit"""
+    def __init__(self, ipy_completer):
+        self.ipy_completer = ipy_completer
+
+    def get_completions(self, document, complete_event):
+        if not document.current_line.strip():
+            return
+
+        used, matches = self.ipy_completer.complete(
+                            line_buffer=document.current_line,
+                            cursor_pos=document.cursor_position_col
+        )
+        start_pos = -len(used)
+        for m in matches:
+            yield Completion(m, start_position=start_pos)
+
+class PTInteractiveShell(ZMQTerminalInteractiveShell):
+    colors_force = True
+
+    pt_cli = None
+
+    vi_mode = Bool(False, config=True,
+        help="Use vi style keybindings at the prompt",
+    )
+
+    highlighting_style = Unicode('', config=True,
+        help="The name of a Pygments style to use for syntax highlighting"
+    )
+
+    highlighting_style_overrides = Dict(config=True,
+        help="Override highlighting format for specific tokens"
+    )
+
+    history_load_length = Integer(1000, config=True,
+        help="How many history items to load into memory"
+    )
+
+    def __init__(self, **kwargs):
+        super(PTInteractiveShell, self).__init__(**kwargs)
+        self.init_prompt_toolkit_cli()
+        self.keep_running = True
+
+    def get_prompt_tokens(self, cli):
+        return [
+            (Token.Prompt, 'In ['),
+            (Token.PromptNum, str(self.execution_count)),
+            (Token.Prompt, ']: '),
+        ]
+
+    def get_continuation_tokens(self, cli, width):
+        return [
+            (Token.Prompt, (' ' * (width - 2)) + ': '),
+        ]
+
+    def init_prompt_toolkit_cli(self):
+        kbmanager = KeyBindingManager.for_prompt(enable_vi_mode=self.vi_mode)
+        insert_mode = ViStateFilter(kbmanager.get_vi_state, InputMode.INSERT)
+        # Ctrl+J == Enter, seemingly
+        @kbmanager.registry.add_binding(Keys.ControlJ,
+                            filter=(HasFocus(DEFAULT_BUFFER)
+                                    & ~HasSelection()
+                                    & insert_mode
+                                   ))
+        def _(event):
+            b = event.current_buffer
+            d = b.document
+            if not (d.on_last_line or d.cursor_position_row >= d.line_count
+                                           - d.empty_line_count_at_the_end()):
+                b.newline()
+                return
+
+            status, indent = self.input_splitter.check_complete(d.text)
+
+            if (status != 'incomplete') and b.accept_action.is_returnable:
+                b.accept_action.validate_and_handle(event.cli, b)
+            else:
+                b.insert_text('\n' + (' ' * (indent or 0)))
+
+        @kbmanager.registry.add_binding(Keys.ControlC)
+        def _(event):
+            event.current_buffer.reset()
+
+        # Pre-populate history from IPython's history database
+        history = InMemoryHistory()
+        last_cell = u""
+        for _, _, cell in self.history_manager.get_tail(self.history_load_length,
+                                                        include_latest=True):
+            # Ignore blank lines and consecutive duplicates
+            cell = cell.rstrip()
+            if cell and (cell != last_cell):
+                history.append(cell)
+
+        style_overrides = {
+            Token.Prompt: '#009900',
+            Token.PromptNum: '#00ff00 bold',
+        }
+        if self.highlighting_style:
+            style_cls = get_style_by_name(self.highlighting_style)
+        else:
+            style_cls = get_style_by_name('default')
+            # The default theme needs to be visible on both a dark background
+            # and a light background, because we can't tell what the terminal
+            # looks like. These tweaks to the default theme help with that.
+            style_overrides.update({
+                Token.Number: '#007700',
+                Token.Operator: 'noinherit',
+                Token.String: '#BB6622',
+                Token.Name.Function: '#2080D0',
+                Token.Name.Class: 'bold #2080D0',
+                Token.Name.Namespace: 'bold #2080D0',
+            })
+        style_overrides.update(self.highlighting_style_overrides)
+        style = PygmentsStyle.from_defaults(pygments_style_cls=style_cls,
+                                            style_dict=style_overrides)
+
+        app = create_prompt_application(multiline=True,
+                            lexer=PygmentsLexer(Python3Lexer if PY3 else PythonLexer),
+                            get_prompt_tokens=self.get_prompt_tokens,
+                            get_continuation_tokens=self.get_continuation_tokens,
+                            key_bindings_registry=kbmanager.registry,
+                            history=history,
+                            completer=IPythonPTCompleter(self.Completer),
+                            enable_history_search=True,
+                            style=style,
+        )
+
+        self.pt_cli = CommandLineInterface(app)
+
+    def init_io(self):
+        if sys.platform not in {'win32', 'cli'}:
+            return
+
+        import colorama
+        colorama.init()
+
+    def ask_exit(self):
+        self.keep_running = False
+
+    rl_next_input = None
+
+    def pre_prompt(self):
+        if self.rl_next_input:
+            self.pt_cli.application.buffer.text = cast_unicode_py2(self.rl_next_input)
+            self.rl_next_input = None
+
+    def interact(self, display_banner=None):
+        while self.keep_running:
+            print('\n', end='')
+
+            try:
+                document = self.pt_cli.run(pre_run=self.pre_prompt)
+            except EOFError:
+                if self.ask_yes_no('Do you really want to exit ([y]/n)?','y','n'):
+                    self.ask_exit()
+
+            else:
+                if document:
+                    self.run_cell(document.text, store_history=True)
+

--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -173,6 +173,13 @@ class PTInteractiveShell(ZMQTerminalInteractiveShell):
             self.rl_next_input = None
 
     def interact(self, display_banner=None):
+        # run a non-empty no-op, so that we don't get a prompt until
+        # we know the kernel is ready. This keeps the connection
+        # message above the first prompt.
+        if not self.wait_for_kernel(self.kernel_timeout):
+            print("Kernel did not respond\n", file=sys.stderr)
+            return
+
         while self.keep_running:
             print('\n', end='')
 

--- a/jupyter_console/tests/test_console.py
+++ b/jupyter_console/tests/test_console.py
@@ -56,9 +56,11 @@ def start_console():
     
     args = ['-m', 'jupyter_console', '--colors=NoColor']
     cmd = sys.executable
-    
+    env = os.environ.copy()
+    env['JUPYTER_CONSOLE_TEST'] = '1'
+
     try:
-        p = pexpect.spawn(cmd, args=args)
+        p = pexpect.spawn(cmd, args=args, env=env)
     except IOError:
         raise SkipTest("Couldn't find command %s" % cmd)
     

--- a/setup.py
+++ b/setup.py
@@ -79,12 +79,12 @@ install_requires = setuptools_args['install_requires'] = [
     'jupyter_client',
     'ipython',
     'ipykernel', # bless IPython kernel for now
+    'prompt_toolkit',
 ]
 
 extras_require = setuptools_args['extras_require'] = {
     'test:python_version=="2.7"': ['mock'],
     'test:sys_platform != "win32"': ['pexpect'],
-    ':sys_platform == "win32"': ['pyreadline'],
 
 }
 


### PR DESCRIPTION
For now, the new class subclasses the existing `ZMQTerminalInteractiveShell`, and therefore inherits from IPython as well. I started trying to do it without that inheritance, but it quickly became clear that that would involve duplicating a lot of code. My new plan is to consolidate code after switching to prompt_toolkit, and break the inheritance between jupyter_console and ipython.