### PR TITLE
Fill readline history before recording its length

### DIFF
--- a/jupyter_console/interactiveshell.py
+++ b/jupyter_console/interactiveshell.py
@@ -570,8 +570,8 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
 
         if self.has_readline:
             self.readline_startup_hook(self.pre_readline)
-            hlen_b4_cell = self.readline.get_current_history_length()
             self.refill_readline_hist()
+            hlen_b4_cell = self.readline.get_current_history_length()
         else:
             hlen_b4_cell = 0
         # exit_now is set by a call to %Exit or %Quit, through the


### PR DESCRIPTION
Closes gh-49

I'm not sure why the call to refill_readline_hist() is needed here at all - it should be called in init_readline() - but from the comments in gh-49, the earlier call doesn't always work. It may be a race condition. It doesn't seem to do any harm to call it again, though.