### PR TITLE
fix printed () in banner issue

### DIFF
--- a/jupyter_console/app.py
+++ b/jupyter_console/app.py
@@ -7,6 +7,8 @@ input, there is no real readline support, among other limitations.
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+from __future__ import print_function
+
 import logging
 import signal
 


### PR DESCRIPTION
Python2 prints an extra `()` in the banner. This fixes that, but does not resolve #59.