### PR TITLE
Update SIGINT handler to not use the old interactive shell API

### DIFF
--- a/jupyter_console/app.py
+++ b/jupyter_console/app.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 
 import logging
 import signal
+import sys
 
 from traitlets import (
     Dict, Any
@@ -91,9 +92,9 @@ class ZMQTerminalIPythonApp(JupyterApp, JupyterConsoleApp):
     aliases = Dict(aliases)
     frontend_aliases = Any(frontend_aliases)
     frontend_flags = Any(frontend_flags)
-    
+
     subcommands = Dict()
-    
+
     force_interact = True
 
     def parse_command_line(self, argv=None):
@@ -119,7 +120,7 @@ class ZMQTerminalIPythonApp(JupyterApp, JupyterConsoleApp):
             if self.kernel_manager:
                 self.kernel_manager.interrupt_kernel()
             else:
-                self.shell.write_err('\n')
+                print("\n", file=sys.stderr, end="\n")
                 error("Cannot interrupt kernels we didn't start.\n")
         else:
             # raise the KeyboardInterrupt if we aren't waiting for execution,
@@ -142,7 +143,7 @@ class ZMQTerminalIPythonApp(JupyterApp, JupyterConsoleApp):
         self.shell.show_banner()
         # Make sure there is a space below the banner.
         if self.log_level <= logging.INFO: print()
-    
+
     def start(self):
         # JupyterApp.start dispatches on NoStart
         super(ZMQTerminalIPythonApp, self).start()

--- a/jupyter_console/app.py
+++ b/jupyter_console/app.py
@@ -120,7 +120,7 @@ class ZMQTerminalIPythonApp(JupyterApp, JupyterConsoleApp):
             if self.kernel_manager:
                 self.kernel_manager.interrupt_kernel()
             else:
-                print("\n", file=sys.stderr, end="\n")
+                print("", file=sys.stderr)
                 error("Cannot interrupt kernels we didn't start.\n")
         else:
             # raise the KeyboardInterrupt if we aren't waiting for execution,


### PR DESCRIPTION
Currently, when using Ctrl-C on the console that connects to an existing kernel, it raises an error:
```
Traceback (most recent call last):
  File "/Users/adrianliaw/.pyenv/versions/py351/bin/jupyter-console", line 9, in <module>
    load_entry_point('jupyter-console', 'console_scripts', 'jupyter-console')()
  File "/Users/adrianliaw/Documents/projects/fork/jupyter_core/jupyter_core/application.py", line 267, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "/Users/adrianliaw/.pyenv/versions/py351/lib/python3.5/site-packages/traitlets/config/application.py", line 596, in launch_instance
    app.start()
  File "/Users/adrianliaw/Documents/projects/fork/jupyter_console/jupyter_console/app.py", line 150, in start
    self.shell.mainloop()
  File "/Users/adrianliaw/Documents/projects/fork/jupyter_console/jupyter_console/ptshell.py", line 462, in mainloop
    self.interact()
  File "/Users/adrianliaw/Documents/projects/fork/jupyter_console/jupyter_console/ptshell.py", line 454, in interact
    self.run_cell(code, store_history=True)
  File "/Users/adrianliaw/Documents/projects/fork/jupyter_console/jupyter_console/ptshell.py", line 505, in run_cell
    self.handle_input_request(msg_id, timeout=0.05)
  File "/Users/adrianliaw/Documents/projects/fork/jupyter_console/jupyter_console/ptshell.py", line 757, in handle_input_request
    req = self.client.stdin_channel.get_msg(timeout=timeout)
  File "/Users/adrianliaw/Documents/projects/fork/jupyter_client/jupyter_client/blocking/channels.py", line 50, in get_msg
    ready = self.socket.poll(timeout)
  File "/Users/adrianliaw/.pyenv/versions/py351/lib/python3.5/site-packages/zmq/sugar/socket.py", line 503, in poll
    evts = dict(p.poll(timeout))
  File "/Users/adrianliaw/.pyenv/versions/py351/lib/python3.5/site-packages/zmq/sugar/poll.py", line 99, in poll
    return zmq_poll(self.sockets, timeout=timeout)
  File "zmq/backend/cython/_poll.pyx", line 122, in zmq.backend.cython._poll.zmq_poll (zmq/backend/cython/_poll.c:1850)
  File "zmq/backend/cython/_poll.pyx", line 115, in zmq.backend.cython._poll.zmq_poll (zmq/backend/cython/_poll.c:1705)
  File "zmq/backend/cython/checkrc.pxd", line 12, in zmq.backend.cython.checkrc._check_rc (zmq/backend/cython/_poll.c:2084)
  File "/Users/adrianliaw/Documents/projects/fork/jupyter_console/jupyter_console/app.py", line 122, in handle_sigint
    self.shell.write_err('\n')
AttributeError: 'ZMQTerminalInteractiveShell' object has no attribute 'write_err'
```
Clearly that app.py used an outdated API on `ZMQTerminalInteractiveShell`, this pull request fixed this.