### PR TITLE
Document making a release and edit _version

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,5 +37,6 @@ Contents:
    :maxdepth: 2
 
    config_options
+   release
    changelog
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -29,7 +29,8 @@ Create the release
 ------------------
 
 #.  Update version number in ``jupyter_console/_version.py``. Make sure that
-    a valid PEP440 version is being used.
+    a valid `PEP 440 <https://www.python.org/dev/peps/pep-0440/>`_ version is
+    being used.
 
 #.  Commit and tag the release with the current version number:
 
@@ -54,6 +55,6 @@ Create the release
         twine upload dist/*
 
 #.  If all went well, change the ``jupyter_console/_version.py`` to the next
-            release.
+    release.
 
 #.  Push directly on master, not forgetting to push ``--tags`` too.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,0 +1,59 @@
+.. _jupyter_console_release:
+
+Making a release as a maintainer
+================================
+
+This document guides a maintainer through creating a release of the Jupyter
+console.
+
+Check installed tools
+---------------------
+
+Review ``CONTRIBUTING.rst``. Make sure all the tools needed are properly
+installed.
+
+Clean the repository
+--------------------
+
+Remove all non-tracked files with:
+
+.. code:: bash
+
+    git clean -xfdi
+
+This will ask you for confirmation before removing all untracked files. Make
+sure the ``dist/`` folder is clean and does not contain any stale builds from
+previous attempts.
+
+Create the release
+------------------
+
+#.  Update version number in ``jupyter_console/_version.py``. Make sure that
+    a valid PEP440 version is being used.
+
+#.  Commit and tag the release with the current version number:
+
+    .. code:: bash
+
+        git commit -am "release $VERSION"
+        git tag $VERSION
+
+#.  You are now ready to build the ``sdist`` and ``wheel``:
+
+    .. code:: bash
+
+        python setup.py sdist --formats=zip,gztar
+        python setup.py bdist_wheel
+
+#.  You can now test the ``wheel`` and the ``sdist`` locally before uploading
+    to PyPI. Make sure to use `twine <https://github.com/pypa/twine>`_ to
+    upload the archives over SSL.
+
+    .. code:: bash
+
+        twine upload dist/*
+
+#.  If all went well, change the ``jupyter_console/_version.py`` to the next
+            release.
+
+#.  Push directly on master, not forgetting to push ``--tags`` too.

--- a/jupyter_console/_version.py
+++ b/jupyter_console/_version.py
@@ -1,2 +1,10 @@
-version_info = (5, 0, 0, 'dev')
-__version__ = '.'.join(map(str, version_info))
+""" For beta/alpha/rc releases, the version number for a beta is X.Y.ZbN 
+**without dots between the last 'micro' number and b**. N is the number of
+the beta released i.e. 1, 2, 3 ...
+
+See PEP 440 https://www.python.org/dev/peps/pep-0440/
+"""
+
+version_info = (5, 0, 0, '.dev')
+
+__version__ = '.'.join(map(str, version_info[:3])) + ''.join(version_info[3:])


### PR DESCRIPTION
Closes #83 

Added documentation based on the issue notes and the GitHub repo.

I adjusted the `_version.py` file's join function to match the [notebook's _version.py](https://github.com/jupyter/notebook/blob/8d091a26b690bbaa3ef1b00e5b590a245b4eb863/notebook/_version.py)