### PR TITLE
Remove colors_force flag

### DIFF
--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -114,7 +114,6 @@ class JupyterPTCompleter(Completer):
             yield Completion(m, start_position=start_pos)
 
 class ZMQTerminalInteractiveShell(SingletonConfigurable):
-    colors_force = True
     readline_use = False
 
     pt_cli = None


### PR DESCRIPTION
See ipython/ipython#9673. This copy wasn't doing anything anyway, since
jupyter_console no longer inherits from IPython.