### PR TITLE
Add option to use 24bit color in prompt toolkit

### DIFF
--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -33,7 +33,7 @@ from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
 from prompt_toolkit.filters import HasFocus, HasSelection, ViInsertMode, EmacsInsertMode
 from prompt_toolkit.history import InMemoryHistory
-from prompt_toolkit.shortcuts import create_prompt_application, create_eventloop
+from prompt_toolkit.shortcuts import create_prompt_application, create_eventloop, create_output
 from prompt_toolkit.interface import CommandLineInterface
 from prompt_toolkit.key_binding.manager import KeyBindingManager
 from prompt_toolkit.key_binding.vi_state import InputMode
@@ -133,6 +133,10 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
 
     highlighting_style_overrides = Dict(config=True,
         help="Override highlighting format for specific tokens"
+    )
+
+    true_color = Bool(False, config=True,
+        help="Use 24bit colors instead of 256 colors in prompt highlighting"
     )
 
     history_load_length = Integer(1000, config=True,
@@ -401,7 +405,10 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
         )
 
         self._eventloop = create_eventloop()
-        self.pt_cli = CommandLineInterface(app, eventloop=self._eventloop)
+        self.pt_cli = CommandLineInterface(app,
+                            eventloop=self._eventloop,
+                            output=create_output(true_color=self.true_color),
+        )
 
     def prompt_for_code(self):
         document = self.pt_cli.run(pre_run=self.pre_prompt,

--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -136,7 +136,10 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
     )
 
     true_color = Bool(False, config=True,
-        help="Use 24bit colors instead of 256 colors in prompt highlighting"
+        help=("Use 24bit colors instead of 256 colors in prompt highlighting. "
+              "If your terminal supports true color, the following command "
+              "should print 'TRUECOLOR' in orange: "
+              "printf \"\\x1b[38;2;255;100;0mTRUECOLOR\\x1b[0m\\n\"")
     )
 
     history_load_length = Integer(1000, config=True,


### PR DESCRIPTION
This exposes the `true_color` option (off by default) in prompt_toolkit so highlighting styles can use the full hex color specification instead of a 256 color approximation (note the code below is just sample code, not part of the PR):

<img width="568" alt="screen shot 2016-07-11 at 7 08 49 am" src="https://cloud.githubusercontent.com/assets/4472522/16733469/8d26bf0e-4736-11e6-8bc8-60b774d1d518.png">

<img width="566" alt="screen shot 2016-07-11 at 7 09 45 am" src="https://cloud.githubusercontent.com/assets/4472522/16733473/911ebef4-4736-11e6-98fc-b81bc37887e5.png">