### PR TITLE
Allow custom pygments lexers

### DIFF
--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -43,7 +43,8 @@ from prompt_toolkit.layout.lexers import PygmentsLexer
 from prompt_toolkit.styles import PygmentsStyle
 
 from pygments.styles import get_style_by_name
-from pygments.lexers import LEXERS, find_lexer_class
+from pygments.lexers import get_lexer_by_name
+from pygments.util import ClassNotFound
 from pygments.token import Token
 
 def ask_yes_no(prompt, default=None, interrupt=None):
@@ -87,13 +88,12 @@ def get_pygments_lexer(name):
         from IPython.lib.lexers import IPython3Lexer
         return IPython3Lexer
     else:
-        for module_name, cls_name, aliases, _, _ in LEXERS.values():
-            if name in aliases:
-                return find_lexer_class(cls_name)
-
-        warn("No lexer found for language %r. Treating as plain text." % name)
-        from pygments.lexers.special import TextLexer
-        return TextLexer
+        try:
+            return get_lexer_by_name(name).__class__
+        except ClassNotFound:
+            warn("No lexer found for language %r. Treating as plain text." % name)
+            from pygments.lexers.special import TextLexer
+            return TextLexer
 
 
 class JupyterPTCompleter(Completer):


### PR DESCRIPTION
Currently, the Jupyter console does not support the use of custom pygments lexers, since instead of using the recommended `get_lexer_by_name` pygments function, it uses the special constant `LEXERS`, which only knows about built-in pygments lexers, not custom ones. This PR changes the lexer discovery logic to correctly use `get_lexer_by_name` instead of `LEXERS`, fixing the issue.