### PR TITLE
Added option to print output of `stream_image_handler` back to console

### DIFF
--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -190,12 +190,6 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
         """
     )
 
-    stream_image_handler_print_output = Bool(False, config=True, help=
-        """
-        Print the STDOUT of the 'stream_image_handler' back to the console.
-        """
-    )
-
     tempfile_image_handler = List(config=True, help=
         """
         Command to invoke an image viewer program when you are using
@@ -782,14 +776,10 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
         fmt = dict(format=imageformat)
         args = [s.format(**fmt) for s in self.stream_image_handler]
         with open(os.devnull, 'w') as devnull:
-            image_out = subprocess.PIPE if self.stream_image_handler_print_output else devnull
             proc = subprocess.Popen(
                 args, stdin=subprocess.PIPE,
-                stdout=image_out, stderr=devnull)
-            out, err = proc.communicate(raw)
-            if self.stream_image_handler_print_output:
-                sys.stdout.flush()
-                sys.stdout.buffer.write(out)
+                stdout=devnull, stderr=devnull)
+            proc.communicate(raw)
         return (proc.returncode == 0)
 
     def handle_image_tempfile(self, data, mime):

--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -189,6 +189,12 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
         """
     )
 
+    stream_image_handler_print_output = Bool(False, config=True, help=
+        """
+        Print the STDOUT of the 'stream_image_handler' back to the console.
+        """
+    )
+
     tempfile_image_handler = List(config=True, help=
         """
         Command to invoke an image viewer program when you are using
@@ -763,10 +769,14 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
         fmt = dict(format=imageformat)
         args = [s.format(**fmt) for s in self.stream_image_handler]
         with open(os.devnull, 'w') as devnull:
+            image_out = subprocess.PIPE if self.stream_image_handler_print_output else devnull
             proc = subprocess.Popen(
                 args, stdin=subprocess.PIPE,
-                stdout=devnull, stderr=devnull)
-            proc.communicate(raw)
+                stdout=image_out, stderr=devnull)
+            out, err = proc.communicate(raw)
+            if self.stream_image_handler_print_output:
+                sys.stdout.flush()
+                sys.stdout.buffer.write(out)
         return (proc.returncode == 0)
 
     def handle_image_tempfile(self, data, mime):


### PR DESCRIPTION
This allows to echo the output of `stream_image_handler` back to the console.

The purpose is a more versatile handling of output from `stream_image_handler`.
I imagine that this will be useful in the future.

For example, this allows to implement the equivalent of `matplotlib`'s `iTerm` backend without mucking around with config files too much.

The setup to achieve similar effect would be:

```python
# ~/.jupyter/jupyter_console_config.py
c = get_config()
c.ZMQTerminalInteractiveShell.image_handler = 'stream'
c.ZMQTerminalInteractiveShell.stream_image_handler = ['imgcat']
# New option:
c.ZMQTerminalInteractiveShell.stream_image_handler_print_output = True
```

![image](https://cloud.githubusercontent.com/assets/1881263/21938480/c7fff63e-d978-11e6-9faa-c867c19d0230.png)

I imagine that this behaviour can also be useful in the future.