### PR TITLE
Cast history to unicode for prompt_toolkit

### DIFF
--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -379,7 +379,7 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
         for _, _, cell in self.history_manager.get_tail(self.history_load_length,
                                                         include_latest=True):
             # Ignore blank lines and consecutive duplicates
-            cell = cell.rstrip()
+            cell = cast_unicode_py2(cell.rstrip())
             if cell and (cell != last_cell):
                 history.append(cell)
 


### PR DESCRIPTION
See ipython/ipython#10014 - at least some people reporting the issue were actually seeing it in `jupyter console`, not IPython. One person in Southampton has confirmed that this seems to fix it for them.