### PR TITLE
Keep "--existing" kernel alive on Ctrl-D exit

### DIFF
--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -486,7 +486,7 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
                     self.run_cell(code, store_history=True)
 
     def mainloop(self):
-        self.keepkernel = False
+        self.keepkernel = not self.own_kernel
         # An extra layer of protection in case someone mashing Ctrl-C breaks
         # out of our internal code.
         while True:


### PR DESCRIPTION
When exiting from `jupyter-console --existing` by pressing Ctrl-D, the expected behavior is that the existing kernel is left alive. See #48 for a discussion. (This might be related to #126, too.)

Currently, however, the kernel is shut down upon console exit. This commit fixes this.

----

Apparently, setting `self.keepkernel = True` affects *only* the Ctrl-D behavior. The `exit` command still has `keep_kernel=False` by default.

Before:

|                          |          `jupyter-console`          | `jupyter-console --existing` |
|:------------------------:|:-----------------------------------:|:----------------------------:|
|          `exit`          |         Shutting down kernel        |     Shutting down kernel     |
| `exit(keep_kernel=True)` | owning kernel, cannot keep it alive |     keeping kernel alive     |
|      Pressing Ctrl-D     |         Shutting down kernel        |   **Shutting down kernel**   |


After:

|                          |          `jupyter-console`          | `jupyter-console --existing` |
|:------------------------:|:-----------------------------------:|:----------------------------:|
|          `exit`          |         Shutting down kernel        |     Shutting down kernel     |
| `exit(keep_kernel=True)` | owning kernel, cannot keep it alive |     keeping kernel alive     |
|      Pressing Ctrl-D     | owning kernel, cannot keep it alive |   **keeping kernel alive**   |
