### PR TITLE
Add bumpversion config file

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,19 @@
+[bumpversion]
+current_version = 5.3.0.dev
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<suffix>.*)
+serialize = 
+	{major}.{minor}.{patch}{suffix}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:suffix]
+optional_value = final
+values = 
+	.dev
+	final
+
+[bumpversion:file:jupyter_console/_version.py]
+parse = (?P<major>\d+),\s*(?P<minor>\d+),\s*(?P<patch>\d+)(,\s*['"](?P<suffix>\w+)['"])?
+serialize = 
+	{major}, {minor}, {patch}, '{suffix}'
+	{major}, {minor}, {patch}
+


### PR DESCRIPTION
I just did the 5.2 release using this:

```
bumpversion suffix
# make release
bumpversion minor
git commit -am "Back to dev"
```

(I did a `git clean` in the process of doing the release, so I had to write it a second time :disappointed: )