### PR TITLE
Upgrade to prompt_toolkit 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ __pycache__
 \#*#
 .#*
 .coverage
+# PyCharm project cache
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ sudo: false
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
-    - pip install --upgrade setuptools pip
+    - pip install --upgrade pip
+    - pip install --upgrade setuptools
+    - pip install git+git://github.com/ipython/ipython.git#egg=ipython
     - pip install -f travis-wheels/wheelhouse --pre -e . coveralls
     - python -m ipykernel.kernelspec --user
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ python:
     - 3.6
     - 3.5
     - 3.4
-    - 3.3
-    - 2.7
 sudo: false
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [bdist_wheel]
 universal=1
+
+[flake8]
+max-line-length = 99
+;ignore = E128, E124, E251, W503

--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,34 @@ name = 'jupyter_console'
 
 import sys
 
-v = sys.version_info
-if v[:2] < (2,7) or (v[0] >= 3 and v[:2] < (3,3)):
-    error = "ERROR: %s requires Python version 2.7 or 3.3 or above." % name
+
+if sys.version_info < (3, 4):
+    pip_message = 'This may be due to an out of date pip. Make sure you have pip >= 9.0.1.'
+    try:
+        import pip
+        pip_version = tuple([int(x) for x in pip.__version__.split('.')[:3]])
+        if pip_version < (9, 0, 1) :
+            pip_message = 'Your pip version is out of date, please install pip >= 9.0.1. '\
+            'pip {} detected.'.format(pip.__version__)
+        else:
+            # pip is new enough - it must be something else
+            pip_message = ''
+    except Exception:
+        pass
+
+
+    error = """
+Jupyter_Console 6.0+ supports Python 3.4 and above.
+When using Python 2.7, please install and older version of Jupyter Console
+Python 3.3 was supported up to Jupyter Console 5.x.
+
+Python {py} detected.
+{pip}
+""".format(py=sys.version_info, pip=pip_message )
+
     print(error, file=sys.stderr)
     sys.exit(1)
 
-PY3 = (sys.version_info[0] >= 3)
 
 #-----------------------------------------------------------------------------
 # get on with it
@@ -65,9 +86,7 @@ setup_args = dict(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
     ],
 )
 
@@ -84,10 +103,13 @@ install_requires = setuptools_args['install_requires'] = [
 ]
 
 extras_require = setuptools_args['extras_require'] = {
-    'test:python_version=="2.7"': ['mock'],
     'test:sys_platform != "win32"': ['pexpect'],
 
+
 }
+
+setuptools_args['python_requires'] = '>=3.4'
+
 
 setuptools_args['entry_points'] = {
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
     'jupyter_client',
     'ipython',
-    'ipykernel', # bless IPython kernel for now
+    'ipykernel>=7.0.0', # bless IPython kernel for now
     'prompt_toolkit>=2.0.0,<2.1.0',
     'pygments',
 ]

--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,8 @@ if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):
 setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
     'jupyter_client',
-    'ipython',
-    'ipykernel>=7.0.0', # bless IPython kernel for now
+    'ipython>=7.0.0',
+    'ipykernel', # bless IPython kernel for now
     'prompt_toolkit>=2.0.0,<2.1.0',
     'pygments',
 ]

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ install_requires = setuptools_args['install_requires'] = [
     'jupyter_client',
     'ipython',
     'ipykernel', # bless IPython kernel for now
-    'prompt_toolkit>=1.0.0,<2.0.0',
+    'prompt_toolkit>=2.0.0,<2.1.0',
     'pygments',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):
 setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
     'jupyter_client',
-    'ipython>=7.0.0',
+    'ipython',
     'ipykernel', # bless IPython kernel for now
     'prompt_toolkit>=2.0.0,<2.1.0',
     'pygments',


### PR DESCRIPTION
This PR concerns #158 .
I tried to follow the changes made in[ ipython/ipython#11177](https://github.com/ipython/ipython/pull/11177). 
It passes the nosetests and works on linux (ubuntu18).
On Windows (gitbash + cmd tested) it only works, but the failed nosetests are the same as on master with the old ``prompt_toolkit `` so i hope its fine and I broke less than i repaired.

@takluyver Quite sneaky to present your tool (``enboard``) at PyData Berlin, knowing it breaks ppls Jupyter.
Thats how you get contributers ;)

P.S.: While i was in the code i did also some PEP8 changes.