### PR TITLE
Install released IPython

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_install:
 install:
     - pip install --upgrade pip
     - pip install --upgrade setuptools
-    - pip install git+git://github.com/ipython/ipython.git#egg=ipython
     - pip install -f travis-wheels/wheelhouse --pre -e . coveralls
     - python -m ipykernel.kernelspec --user
 script:


### PR DESCRIPTION
Now that IPython 7 has been released, we can install from PyPI.