### PR TITLE
Add and Use win_unicode_console

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 python:
     - 3.6
     - 3.5
+    - 3.4
+    - 3.3
+    - 2.7
 sudo: false
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,8 @@ sudo: false
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
-    - pip install --upgrade pip
     # Work around newer pip failing on python 3.3
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then pip install -I pip==10.*; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then pip install -I pip==10.*; else; pip install --upgrade pip; fi
     - pip install --upgrade setuptools
     - pip install -f travis-wheels/wheelhouse --pre -e . coveralls
     - python -m ipykernel.kernelspec --user

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ language: python
 python:
     - 3.6
     - 3.5
-    - 3.4
-    - 3.3
-    - 2.7
 sudo: false
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
-    - pip install --upgrade setuptools pip
+    - pip install --upgrade pip
+    # Work around newer pip failing on python 3.3
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then pip install -I pip==10.*; fi
+    - pip install --upgrade setuptools
     - pip install -f travis-wheels/wheelhouse --pre -e . coveralls
     - python -m ipykernel.kernelspec --user
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
     # Work around newer pip failing on python 3.3
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then pip install -I pip==10.*; else; pip install --upgrade pip; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then pip install -I pip==10.*; else pip install --upgrade pip; fi
     - pip install --upgrade setuptools
     - pip install -f travis-wheels/wheelhouse --pre -e . coveralls
     - python -m ipykernel.kernelspec --user

--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -440,9 +440,20 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
                                    reset_current_buffer=True)
         return document.text
 
+    def enable_win_unicode_console(self):
+        if sys.version_info >= (3, 6):
+            # Since PEP 528, Python uses the unicode APIs for the Windows
+            # console by default, so WUC shouldn't be needed.
+            return
+
+        import win_unicode_console
+        win_unicode_console.enable()
+
     def init_io(self):
         if sys.platform not in {'win32', 'cli'}:
             return
+
+        self.enable_win_unicode_console()
 
         import colorama
         colorama.init()

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,9 @@ install_requires = setuptools_args['install_requires'] = [
     'ipykernel', # bless IPython kernel for now
     'prompt_toolkit>=1.0.0,<2.0.0',
     'pygments',
+    'colorama;sys_platform=="win32"',
+    'win_unicode_console>=0.5;sys_platform=="win32" and python_version < "3.6"',
+
 ]
 
 extras_require = setuptools_args['extras_require'] = {

--- a/setup.py
+++ b/setup.py
@@ -76,17 +76,16 @@ if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):
 
 setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
-    'jupyter_client',
-    'ipython',
-    'ipykernel', # bless IPython kernel for now
+    'jupyter_client<6.0.0',
+    'ipython<6.0.0',
+    'ipykernel<5.0.0', # bless IPython kernel for now
     'prompt_toolkit>=1.0.0,<2.0.0',
     'pygments',
-    'colorama;sys_platform=="win32"',
-    'win_unicode_console>=0.5;sys_platform=="win32" and python_version < "3.6"',
-
 ]
 
 extras_require = setuptools_args['extras_require'] = {
+    ':sys_platform=="win32"': ['colorama'],
+    ':sys_platform=="win32" and python_version < "3.6"': ['win_unicode_console>=0.5'],
     'test:python_version=="2.7"': ['mock'],
     'test:sys_platform != "win32"': ['pexpect'],
 

--- a/setup.py
+++ b/setup.py
@@ -76,9 +76,9 @@ if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):
 
 setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
-    'jupyter_client<6.0.0',
+    'jupyter_client',
     'ipython<6.0.0',
-    'ipykernel<5.0.0', # bless IPython kernel for now
+    'ipykernel', # bless IPython kernel for now
     'prompt_toolkit>=1.0.0,<2.0.0',
     'pygments',
 ]


### PR DESCRIPTION
Before this commit, python 2 on windows would throw an encoding
exception when requested to print a unicode character. I copied some
code from the original IPython repo that handled this problem