### PR TITLE
Giving vi mode some more love 💌

### DIFF
--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -273,6 +273,10 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
     highlight_matching_brackets = Bool(True,
         help="Highlight matching brackets.",
     ).tag(config=True)
+    
+    prompt_includes_vi_mode = Bool(True,
+        help="Display the current vi mode (when using vi editing mode)."
+    ).tag(config=True)
 
     manager = Instance('jupyter_client.KernelManager', allow_none=True)
     client = Instance('jupyter_client.KernelClient', allow_none=True)
@@ -318,10 +322,17 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
         self.history_manager = ZMQHistoryManager(client=self.client)
         self.configurables.append(self.history_manager)
 
+    def vi_mode(self):
+        if (getattr(self, 'editing_mode', None) == 'vi'
+                and self.prompt_includes_vi_mode):
+            return '['+str(self.pt_cli.app.vi_state.input_mode)[3:6]+'] '
+        return ''
+    
     def get_prompt_tokens(self, ec=None):
         if ec is None:
             ec = self.execution_count
         return [
+            (Token.Prompt, self.vi_mode()),
             (Token.Prompt, 'In ['),
             (Token.PromptNum, str(ec)),
             (Token.Prompt, ']: '),


### PR DESCRIPTION
Inspired by [IPython](https://github.com/ipython/ipython/pull/11390/commits/5c6aa5ea5ad94ae0f40d8e04faa348a7003ef8cb).  Add prompt indicators for `[ins]` and `[norm]`.

ToDo:  Add different colors for `ins` and `norm`
Maybe add indicators for other modes such as recording or command