### PR TITLE
Add support for prompt-toolkit v3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ install_requires = setuptools_args['install_requires'] = [
     'jupyter_client',
     'ipython',
     'ipykernel', # bless IPython kernel for now
-    'prompt_toolkit>=2.0.0,<2.1.0,<3.1.0,!=3.0.0,!=3.0.1',
+    'prompt_toolkit>=2.0.0,<3.1.0,!=3.0.0,!=3.0.1',
     'pygments',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ install_requires = setuptools_args['install_requires'] = [
     'jupyter_client',
     'ipython',
     'ipykernel', # bless IPython kernel for now
-    'prompt_toolkit>=2.0.0,<2.1.0',
+    'prompt_toolkit>=2.0.0,<2.1.0,<3.1.0,!=3.0.0,!=3.0.1',
     'pygments',
 ]
 


### PR DESCRIPTION
No changes other than setup.py are required to support prompt-toolkit
since the only breaking changes are related to the async event loop which
are not used by jupyter_console.

Closes #193 