### PR TITLE
Update of #133 : Async prompt for real time update from other clients

### DIFF
--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -40,7 +40,7 @@ from prompt_toolkit.layout.processors import (ConditionalProcessor,
 from prompt_toolkit.styles import merge_styles
 from prompt_toolkit.styles.pygments import (style_from_pygments_cls,
                                             style_from_pygments_dict)
-from prompt_toolkit.formatted_text import PygmentsTokens
+from prompt_toolkit.formatted_text import PygmentsTokens, FormattedText
 from prompt_toolkit.output import ColorDepth
 from prompt_toolkit.utils import suspend_to_background_supported
 
@@ -775,11 +775,29 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
                         if 'text/plain' in data:
                             print(data['text/plain'])
 
+                # If execute input: print it
                 elif msg_type == 'execute_input':
                     content = sub_msg['content']
+
+                    # New line
+                    sys.stdout.write('\n')
+                    sys.stdout.flush()
+
+                    # With `[remote]` prefix
                     if not self.from_here(sub_msg):
-                        sys.stdout.write(self.other_output_prefix)
-                    sys.stdout.write('In [{}]: '.format(content['execution_count']))
+                        print_formatted_text(FormattedText([
+                            ('#ffff00', self.other_output_prefix)]), end='')
+
+                    # Then In[3]
+                    def get_remote_prompt(i):
+                        return FormattedText([
+                            ('#999900', 'In ['),
+                            ('#ffff00', str(i)),
+                            ('#999900', ']: '),
+                        ])
+                    print_formatted_text(get_remote_prompt(content['execution_count']), end='')
+
+                    # And the code
                     sys.stdout.write(content['code'] + '\n')
 
                 elif msg_type == 'clear_output':

--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -373,7 +373,7 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
             def prompt():
                 prompt = 'In [%d]: ' % self.execution_count
                 raw = yield from async_input(prompt)
-                return cast_unicode_py2(raw)
+                return raw
             self.prompt_for_code = prompt
             self.print_out_prompt = \
                 lambda: print('Out[%d]: ' % self.execution_count, end='')

--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -342,6 +342,16 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
         print_formatted_text(PygmentsTokens(tokens), end='',
                              style = self.pt_cli.app.style)
 
+    def get_remote_prompt_tokens(self):
+        return [
+            (Token.RemotePrompt, self.other_output_prefix),
+        ]
+
+    def print_remote_prompt(self):
+        tokens = self.get_remote_prompt_tokens() + self.get_prompt_tokens()
+        print_formatted_text(PygmentsTokens(tokens), end='',
+                             style = self.pt_cli.app.style)
+
     kernel_info = {}
 
     def init_kernel_info(self):
@@ -432,6 +442,7 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
             Token.PromptNum: '#00ff00 bold',
             Token.OutPrompt: '#ff2200',
             Token.OutPromptNum: '#ff0000 bold',
+            Token.RemotePrompt: '#999900',
         }
         if self.highlighting_style:
             style_cls = get_style_by_name(self.highlighting_style)
@@ -837,19 +848,8 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
                     sys.stdout.write('\n')
                     sys.stdout.flush()
 
-                    # With `[remote]` prefix
-                    if not self.from_here(sub_msg):
-                        print_formatted_text(FormattedText([
-                            ('#ffff00', self.other_output_prefix)]), end='')
-
-                    # Then In[3]
-                    def get_remote_prompt(i):
-                        return FormattedText([
-                            ('#999900', 'In ['),
-                            ('#ffff00', str(i)),
-                            ('#999900', ']: '),
-                        ])
-                    print_formatted_text(get_remote_prompt(content['execution_count']), end='')
+                    # With `Remote In [3]: `
+                    self.print_remote_prompt()
 
                     # And the code
                     sys.stdout.write(content['code'] + '\n')

--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -715,8 +715,6 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
     include_other_output = Bool(False, config=True,
         help="""Whether to include output from clients
         other than this one sharing the same kernel.
-
-        Outputs are not displayed until enter is pressed.
         """
     )
     other_output_prefix = Unicode("[remote] ", config=True,

--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -830,6 +830,12 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
                         print()
                     print(text_repr)
 
+                    # Remote: add new prompt
+                    if not self.from_here(sub_msg):
+                        sys.stdout.write('\n')
+                        sys.stdout.flush()
+                        self.print_remote_prompt()
+
                 elif msg_type == 'display_data':
                     data = sub_msg["content"]["data"]
                     handled = self.handle_rich_data(data)

--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -728,7 +728,7 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
         other than this one sharing the same kernel.
         """
     )
-    other_output_prefix = Unicode("[remote] ", config=True,
+    other_output_prefix = Unicode("Remote ", config=True,
         help="""Prefix to add to outputs coming from clients other than this one.
 
         Only relevant if include_other_output is True.


### PR DESCRIPTION
Rebased and checked @wendazhou pull request to add async methods

Feature: With `include_other_output`: Get remote prompt without having to click on enter
![jupyter-vim7](https://user-images.githubusercontent.com/6123962/70585922-7f25ed80-1ba4-11ea-8817-c0575e3621b1.gif)
