### PR TITLE
Fix import of cast_unicode_py2

### DIFF
--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -19,7 +19,8 @@ except ImportError:
 
 from zmq import ZMQError
 from IPython.core import page
-from IPython.utils.py3compat import cast_unicode_py2, input
+from IPython.utils.py3compat import input
+from ipython_genutils.py3compat import cast_unicode_py2
 from ipython_genutils.tempdir import NamedFileInTemporaryDirectory
 from traitlets import (Bool, Integer, Float, Unicode, List, Dict, Enum,
                        Instance, Any)


### PR DESCRIPTION
Fixes #198. I have verified that after making this change in a local venv I can run jupyter-console again.