### PR TITLE
Use encodebytes and decodebytes from base64 instead of deprecated aliases.

### DIFF
--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -818,12 +818,12 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
             from PIL import Image, ImageShow
         except ImportError:
             return False
-        raw = base64.decodestring(data[mime].encode('ascii'))
+        raw = base64.decodebytes(data[mime].encode('ascii'))
         img = Image.open(BytesIO(raw))
         return ImageShow.show(img)
 
     def handle_image_stream(self, data, mime):
-        raw = base64.decodestring(data[mime].encode('ascii'))
+        raw = base64.decodebytes(data[mime].encode('ascii'))
         imageformat = self._imagemime[mime]
         fmt = dict(format=imageformat)
         args = [s.format(**fmt) for s in self.stream_image_handler]
@@ -835,7 +835,7 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
         return (proc.returncode == 0)
 
     def handle_image_tempfile(self, data, mime):
-        raw = base64.decodestring(data[mime].encode('ascii'))
+        raw = base64.decodebytes(data[mime].encode('ascii'))
         imageformat = self._imagemime[mime]
         filename = 'tmp.{0}'.format(imageformat)
         with NamedFileInTemporaryDirectory(filename) as f, \

--- a/jupyter_console/tests/test_image_handler.py
+++ b/jupyter_console/tests/test_image_handler.py
@@ -32,7 +32,7 @@ class ZMQTerminalInteractiveShellTestCase(unittest.TestCase):
         self.shell = NonCommunicatingShell()
         self.raw = b'dummy data'
         self.mime = 'image/png'
-        self.data = {self.mime: base64.encodestring(self.raw).decode('ascii')}
+        self.data = {self.mime: base64.encodebytes(self.raw).decode('ascii')}
 
     def test_call_pil_by_default(self):
         pil_called_with = []


### PR DESCRIPTION
* `encodestring` and `decodestring` were deprecated since Python 3.1