### PR TITLE
Fix package name typo in installation docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ The console can be installed with::
 
 If you want to use conda instead to perform your installation::
 
-    conda install -c conda-forge jupyter-console
+    conda install -c conda-forge jupyter_console
 
 And started with::
 


### PR DESCRIPTION
It looks like the package on conda forge has the name `jupyter_console`, not `jupyter-console`. See https://anaconda.org/conda-forge/jupyter_console/ and https://github.com/conda-forge/jupyter_console-feedstock

Edit: didn't see #175, this is a duplicate