### PR TITLE
The conda-forge package is called jupyter_console

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ The console can be installed with::
 
 If you want to use conda instead to perform your installation::
 
-    conda install -c conda-forge jupyter-console
+    conda install -c conda-forge jupyter_console
 
 And started with::
 


### PR DESCRIPTION
The package is not called jupyter-console.