### PR TITLE
Add usage of completion metadata

### DIFF
--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -115,7 +115,7 @@ class JupyterPTCompleter(Completer):
         )
         start_pos = content['cursor_start'] - document.cursor_position
         for m in content['matches']:
-            yield Completion(m, start_position=start_pos)
+            yield Completion(m, start_position=start_pos, display_meta=content["metadata"].get(m, ""))
 
 
 class ZMQTerminalInteractiveShell(SingletonConfigurable):


### PR DESCRIPTION
Right now completion metadata [appears in the protocol](https://jupyter-client.readthedocs.io/en/stable/messaging.html#msging-completion) but is completely ignored by this frontend. 

Because there isn't a standard for how the metadata should look I implemented what I think the simplest version would be: A dictionary of `{match:metadata}`.