### PR TITLE
Drop testing 3.6 on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - 3.6
     - 3.7
     - 3.8
 before_install:


### PR DESCRIPTION
We do test it with pytest on github actions; and travis also runs mypy,
travis is also slower to start; so this will likely help test to finish
faster.