### PR TITLE
setup.py: update error message for Python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,10 @@ if sys.version_info < (3, 6):
 
 
     error = """
-Jupyter_Console 6.0+ supports Python 3.5 and above.
+Jupyter_Console 6.2+ supports Python 3.6 and above.
 When using Python 2.7, please install and older version of Jupyter Console
 Python 3.3 and 3.4 were supported up to Jupyter Console 5.x.
+Python 3.5 was supported up to Jupyter Console 6.1.0.
 
 Python {py} detected.
 {pip}


### PR DESCRIPTION
Jupyter Console 6.2.0 dropped support for Python 3.5 (see 81beabd), but an outdated error message is currently shown when trying to install on Python 3.5; it suggests Python 3.5 is supported rather than unsupported.