### PR TITLE
Prepare for jupyter_client 7.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,6 @@ jobs:
         pip install pytest pytest-cov
         pip install .
         python -m ipykernel.kernelspec --user
-        pip install https://github.com/jupyter/jupyter_client/archive/master.zip
     - name: Test with pytest
       run: |
         pytest --cov jupyter_console

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,6 +29,7 @@ jobs:
         pip install pytest pytest-cov
         pip install .
         python -m ipykernel.kernelspec --user
+        pip install https://github.com/jupyter/jupyter_client/archive/master.zip
     - name: Test with pytest
       run: |
         pytest --cov jupyter_console

--- a/jupyter_console/completer.py
+++ b/jupyter_console/completer.py
@@ -7,6 +7,16 @@
 from traitlets.config import Configurable
 from traitlets import Float
 
+import jupyter_client
+
+
+# jupyter_client 7.0+ has async channel methods that we expect to be sync here
+if jupyter_client._version.version_info[0] >= 7:
+    from jupyter_client.utils import run_sync
+else:
+    run_sync = lambda x: x
+
+
 class ZMQCompleter(Configurable):
     """Client-side completion machinery.
 
@@ -31,7 +41,7 @@ class ZMQCompleter(Configurable):
             cursor_pos=cursor_pos,
         )
     
-        msg = self.client.shell_channel.get_msg(timeout=self.timeout)
+        msg = run_sync(self.client.shell_channel.get_msg)(timeout=self.timeout)
         if msg['parent_header']['msg_id'] == msg_id:
             return msg['content']
 

--- a/jupyter_console/completer.py
+++ b/jupyter_console/completer.py
@@ -11,7 +11,7 @@ import jupyter_client
 
 
 # jupyter_client 7.0+ has async channel methods that we expect to be sync here
-if jupyter_client._version.version_info[0] >= 7:
+if jupyter_client.version_info >= (7,):
     from jupyter_client.utils import run_sync
 else:
     run_sync = lambda x: x

--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -76,7 +76,14 @@ from pygments.lexers import get_lexer_by_name
 from pygments.util import ClassNotFound
 from pygments.token import Token
 
-from jupyter_client.utils import run_sync
+import jupyter_client
+
+
+# jupyter_client 7.0+ has async channel methods that we expect to be sync here
+if jupyter_client._version.version_info[0] >= 7:
+    from jupyter_client.utils import run_sync
+else:
+    run_sync = lambda x: x
 
 
 def ask_yes_no(prompt, default=None, interrupt=None):
@@ -1034,6 +1041,6 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
 
             # only send stdin reply if there *was not* another request
             # or execution finished while we were reading.
-            if not (self.client.stdin_channel.msg_ready() or
-                    self.client.shell_channel.msg_ready()):
+            if not (run_sync(self.client.stdin_channel.msg_ready)() or
+                    run_sync(self.client.shell_channel.msg_ready)()):
                 self.client.input(raw_data)


### PR DESCRIPTION
jupyter_console seems to directly use jupyter_client's `ZMQSocketChannel`'s methods through a `KernelClient`, instead of e.g. `BlockingKernelClient`. These methods are now async in jupyter_client master (and in the next 7.0 release). One option is to wrap each of these method calls with `run_sync`.
I've done this change so that it fixes https://github.com/jupyter/jupyter_client/issues/653, but there might be other places where this is needed.