### PR TITLE
Automated Changelog Entry for 6.4.1 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Merged PRs
 
 - Prepare for use with Jupyter Releaser [#261](https://github.com/jupyter/jupyter_console/pull/261) ([@davidbrochart](https://github.com/davidbrochart))
+- Prepare for jupyter_client 7.0 [#244](https://github.com/jupyter/jupyter_console/pull/244) ([@davidbrochart](https://github.com/davidbrochart))
+- Added programming language classifiers [#253](https://github.com/jupyter/jupyter_console/pull/253) ([@emuccino](https://github.com/emuccino))
 
 ### Contributors to this release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,23 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
-## 6.4.0
+## 6.4.1
+
+([Full Changelog](https://github.com/jupyter/jupyter_console/compare/6.4.0...2d0b6aec59bde7499995d929ded4d23d7bb585f6))
+
+### Merged PRs
+
+- Prepare for use with Jupyter Releaser [#261](https://github.com/jupyter/jupyter_console/pull/261) ([@davidbrochart](https://github.com/davidbrochart))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter/jupyter_console/graphs/contributors?from=2021-03-24&to=2022-03-06&type=c))
+
+[@davidbrochart](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_console+involves%3Adavidbrochart+updated%3A2021-03-24..2022-03-06&type=Issues) | [@NeilGirdhar](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_console+involves%3ANeilGirdhar+updated%3A2021-03-24..2022-03-06&type=Issues) | [@tinmarino](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_console+involves%3Atinmarino+updated%3A2021-03-24..2022-03-06&type=Issues)
 
 <!-- <END NEW CHANGELOG ENTRY> -->
+
+## 6.4.0
 
 ## 5.3.0
 
@@ -60,7 +74,6 @@
 - readline/completion fixes
 - use is_complete messages to determine if input is complete (important for non-Python kernels)
 - fix: 4.0 was looking for jupyter_console_config in IPython config directories, not Jupyter
-
 
 ## 4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ([GitHub contributors page for this release](https://github.com/jupyter/jupyter_console/graphs/contributors?from=2021-03-24&to=2022-03-06&type=c))
 
-[@davidbrochart](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_console+involves%3Adavidbrochart+updated%3A2021-03-24..2022-03-06&type=Issues) | [@NeilGirdhar](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_console+involves%3ANeilGirdhar+updated%3A2021-03-24..2022-03-06&type=Issues) | [@tinmarino](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_console+involves%3Atinmarino+updated%3A2021-03-24..2022-03-06&type=Issues)
+[@davidbrochart](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_console+involves%3Adavidbrochart+updated%3A2021-03-24..2022-03-06&type=Issues) | [@emuccino](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_console+involves%3Aemuccino+updated%3A2021-03-24..2022-03-06&type=Issues)
 
 <!-- <END NEW CHANGELOG ENTRY> -->
 


### PR DESCRIPTION
Automated Changelog Entry for 6.4.1 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter/jupyter_console  |
| Branch  | main  |
| Version Spec | 6.4.1 |
| Since | 6.4.0 |