### PR TITLE
Use loop.create_task with interact()

### DIFF
--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -656,7 +656,7 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
         # out of our internal code.
         while True:
             try:
-                tasks = [self.interact(loop=loop)]
+                tasks = [loop.create_task(self.interact(loop=loop))]
 
                 if self.include_other_output:
                     # only poll the iopub channel asynchronously if we


### PR DESCRIPTION
Passing coroutines directly to asyncio.wait is deprecated since Python 3.8, as it [leads to confusing behavior](https://docs.python.org/3.10/library/asyncio-task.html#asyncio-example-wait-coroutine).

In Python 3.11, `wait()` will no longer accept coroutines and must be given Tasks.