### PR TITLE
Automated Changelog Entry for 6.4.4 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Merged PRs
 
-- Use loop.create_task with interact() [#270](https://github.com/jupyter/jupyter_console/pull/270) ([@encukou](https://github.com/encukou))
+- Use asyncio.create_task and asyncio.get_running_loop with interact(). Drop Python 3.6. [#270](https://github.com/jupyter/jupyter_console/pull/270) ([@encukou](https://github.com/encukou))
 
 ### Contributors to this release
 


### PR DESCRIPTION
Automated Changelog Entry for 6.4.4 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter/jupyter_console  |
| Branch  | main  |
| Version Spec | next |
| Since | v6.4.3 |