### PR TITLE
Add configurable autoindent option to ZMQTerminalInteractiveShell

### DIFF
--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -203,6 +203,10 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
               "printf \"\\x1b[38;2;255;100;0mTRUECOLOR\\x1b[0m\\n\"")
     )
 
+    autoindent = Bool(True, config=True,
+        help="Autoindent code entered interactively."
+    )
+
     history_load_length = Integer(1000, config=True,
         help="How many history items to load into memory"
     )
@@ -481,7 +485,10 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
             if (not more) and b.accept_handler:
                 b.validate_and_handle()
             else:
-                b.insert_text('\n' + indent)
+                if self.autoindent:
+                    b.insert_text('\n' + indent)
+                else:
+                    b.insert_text('\n')
 
         @kb.add("c-c", filter=has_focus(DEFAULT_BUFFER))
         def _(event):


### PR DESCRIPTION
New `ZMQTerminalInteractiveShell.autoindent` config option to emulate `--no-autoindent` command line option in `ipython`. This was present in the previous `ipython` based `InteractiveShell` class and has been requested by a couple of users (#240).