### PR TITLE
Fix vi input mode enum bug

### DIFF
--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -372,7 +372,7 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
     def vi_mode(self):
         if (getattr(self, 'editing_mode', None) == 'vi'
                 and self.prompt_includes_vi_mode):
-            return '['+str(self.pt_cli.app.vi_state.input_mode)[3:6]+'] '
+            return '['+self.pt_cli.app.vi_state.input_mode[3:6]+'] '
         return ''
 
     def get_prompt_tokens(self, ec=None):


### PR DESCRIPTION
With the `vi` options 
```python
c.ZMQTerminalInteractiveShell.editing_mode = 'vi'
c.ZMQTerminalInteractiveShell.prompt_includes_vi_mode = True
```
specified in `jupyter_console_config.py`, the terminal output, in all `vi` modes, looks like:

![2023-03-30T09:45:19,921232808+02:00](https://user-images.githubusercontent.com/49307119/228771903-6f0dfac5-e0c8-474b-9eea-a161260633fc.png)



The reason for the error is found [here](https://github.com/jsr-p/jupyter_console/blob/fddbc42d2e0be85feace1fe783a05e2b569fceae/jupyter_console/ptshell.py#L375).
The `Enum` `self.pt_cli.app.vi_state.input_mode` is passed into the `str` function, which only shows the the enum name and member name, not the value of the member, cf the Python [docs](https://docs.python.org/3/howto/enum.html#enum-howto).
The `Enum` used is the `InputMode.INSERT` `Enum` from `prompt_toolkit` defined [here](https://github.com/prompt-toolkit/python-prompt-toolkit/blob/a329a88961574c0e6f6415aa46cbd69d1b4d1a22/src/prompt_toolkit/key_binding/vi_state.py#L19).
Applying the `str` function returns `InputMode.INSERT` and subsetting this with `[3:6]` yields the `utM` shown in the terminal screenshot.

This pull requests fixes this issue by simply removing the application of the `str` function before subsetting the enum member. This is also what is done in the `IPython` repo [here](https://github.com/ipython/ipython/blob/c14f8408f560e322c23936e1ff9f8c4b2ccb8611/IPython/terminal/prompts.py#L24). 


