### PR TITLE
Fix behavior of the console in response to Ctrl-C

### DIFF
--- a/jupyter_console/ptshell.py
+++ b/jupyter_console/ptshell.py
@@ -639,7 +639,9 @@ class ZMQTerminalInteractiveShell(SingletonConfigurable):
             print('\n', end='')
 
             try:
+                real_handler = signal.getsignal(signal.SIGINT)
                 code = await self.prompt_for_code()
+                signal.signal(signal.SIGINT, real_handler)
             except EOFError:
                 if (not self.confirm_exit) or \
                         ask_yes_no('Do you really want to exit ([y]/n)?', 'y', 'n'):


### PR DESCRIPTION
The proposed changes are fixing the issue with processing SIGINT when Ctrl-C is pressed to interrupt a running cell. The new fixed behavior is consistent with `jupyter-qtconsole`.

### Behavior before the fix

1. Kernel created by the console

```
$ jupyter-console
Jupyter console 6.6.3

Python 3.10.10 | packaged by conda-forge | (main, Mar 24 2023, 20:08:06) [GCC 11.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.12.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import time

In [2]: for n in range(20):
   ...:     time.sleep(1)
   ...: 
^C
KeyboardInterrupt escaped interact()
```
The task is not stopped, so the next command fails:
```
In [3]: 2 + 4/home/user/Projects/jupyter_console/jupyter_console/ptshell.py:787: UserWarning: The kernel did not respond to an is_complete_request. Setting `use_kernel_is_complete` to False.
  warn('The kernel did not respond to an is_complete_request. '
In [3]: 2 + 4
```

Unresponsive until the execution of the original command is complete (20 seconds).

```
In [3]: 2 + 46
Out[3]: In [3]: 2 + 4
   ...: 
```

2. Connecting to existing kernel

```
$ jupyter-console --existing
Jupyter console 6.6.3

Python 3.10.10 | packaged by conda-forge | (main, Mar 24 2023, 20:08:06) [GCC 11.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.12.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import time

In [7]: for n in range(20):
   ...:     time.sleep(1)
   ...: 
^C
KeyboardInterrupt escaped interact()
```
(The kernel keeps executing the cell, the console needs to be restarted to continue normal operation).

### Behavior After the Fix

1. Kernel created by the console

```
$ jupyter-console
Jupyter console 6.6.3

Python 3.10.10 | packaged by conda-forge | (main, Mar 24 2023, 20:08:06) [GCC 11.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.12.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import time

In [2]: for n in range(20):
   ...:     time.sleep(1)
   ...: 
^C---------------------------------------------------------------------------
KeyboardInterrupt                         Traceback (most recent call last)
Cell In[2], line 2
      1 for n in range(20):
----> 2     time.sleep(1)

KeyboardInterrupt: 

In [3]: 
```

( The running cell is immediately stopped and the console is ready for the next command)

3. Connecting to existing kernel (Ctrl-C is ignored, task can not be stopped)

```
$ jupyter-console --existing
Jupyter console 6.6.3

Python 3.10.10 | packaged by conda-forge | (main, Mar 24 2023, 20:08:06) [GCC 11.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.12.0 -- An enhanced Interactive Python. Type '?' for help.

IPython profile: collection_sim

In [1]: import time

In [13]: for n in range(20):
    ...:     time.sleep(1)
    ...: 
^CERROR: Cannot interrupt kernels we didn't start.
```
(The running cell can not be stopped by design, the console displays normal message and continues to work normally after the cell execution is complete)