### PR TITLE
Replace `@flaky.flaky` decorate with pytest marker

### DIFF
--- a/jupyter_console/tests/test_console.py
+++ b/jupyter_console/tests/test_console.py
@@ -9,7 +9,6 @@ import sys
 import tempfile
 from subprocess import check_output
 
-from flaky import flaky
 import pytest
 
 from traitlets.tests.utils import check_help_all_output
@@ -18,7 +17,7 @@ from traitlets.tests.utils import check_help_all_output
 should_skip = sys.platform == "win32" or sys.version_info < (3,8) or sys.version_info[:2] == (3, 10)  # noqa
 
 
-@flaky
+@pytest.mark.flaky
 @pytest.mark.skipif(should_skip, reason="not supported")
 def test_console_starts():
     """test that `jupyter console` starts a terminal"""
@@ -33,7 +32,7 @@ def test_help_output():
     check_help_all_output('jupyter_console')
 
 
-@flaky
+@pytest.mark.flaky
 @pytest.mark.skipif(should_skip, reason="not supported")
 def test_display_text():
     "Ensure display protocol plain/text key is supported"


### PR DESCRIPTION
Use the `@pytest.mark.flaky` marker in place of the `@flaky.flaky` decorator, to modernize the code and improve compatibility with other plugins providing the feature such as `pytest-rerunfailures`.